### PR TITLE
Refactor : 중복 닉네임 조회 방식 변경

### DIFF
--- a/src/main/java/io/urdego/urdego_user_service/domain/entity/User.java
+++ b/src/main/java/io/urdego/urdego_user_service/domain/entity/User.java
@@ -71,7 +71,7 @@ public class User extends BaseTimeEntity{
 	@JoinColumn(name = "active_character_id",nullable = true)
 	private GameCharacter activeCharacter;
 
-	public static User create(UserSignUpRequest signUpRequest, int nicknameNum) {
+	public static User create(UserSignUpRequest signUpRequest, Long nicknameNum) {
 		return User.builder()
 				.name(signUpRequest.nickname())
 				.nickname(signUpRequest.nickname() +"#"+nicknameNum)

--- a/src/main/java/io/urdego/urdego_user_service/domain/repository/UserRepository.java
+++ b/src/main/java/io/urdego/urdego_user_service/domain/repository/UserRepository.java
@@ -24,8 +24,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmailAndPlatformType(String email, PlatformType platformType);
 
 	//이름으로 검색한 회원 리스트
-	List<User> findByName(String name);
+	//List<User> findByName(String name);
 
+	@Query("SELECT COUNT (u.id) from User u where u. name = :name")
+	Long countByName(@Param("name") String name);
 
     Optional<User> findByNicknameAndIsDeletedFalse(String nickname);
 

--- a/src/main/java/io/urdego/urdego_user_service/domain/service/components/UserCommander.java
+++ b/src/main/java/io/urdego/urdego_user_service/domain/service/components/UserCommander.java
@@ -40,7 +40,7 @@ public class UserCommander {
 
     // 신규 회원가입
     public User signUp(UserSignUpRequest userSignUpRequest) {
-        int nicknameNumber = countDuplicatedNickname(userSignUpRequest.nickname());
+        Long nicknameNumber = countDuplicatedNickname(userSignUpRequest.nickname());
         User newUser = User.create(userSignUpRequest,nicknameNumber);
 
         UserCharacter userCharacter = userCharacterCommander.initActiveCharacter(newUser);
@@ -53,7 +53,7 @@ public class UserCommander {
 
     // 회원 탈퇴 후 재가입
     public User reSignUp(User existingUser, UserSignUpRequest userSignUpRequest) {
-        int nicknameNumber = countDuplicatedNickname(userSignUpRequest.nickname());
+        Long nicknameNumber = countDuplicatedNickname(userSignUpRequest.nickname());
         existingUser.initUserInfo(userSignUpRequest.platformId());
         existingUser.updateNickname(userSignUpRequest.nickname() +"#"+nicknameNumber);
         userCharacterCommander.initActiveCharacter(existingUser);
@@ -74,9 +74,10 @@ public class UserCommander {
     }
 
     // 회원가입 시 닉네임 넘버링
-    private int countDuplicatedNickname(String nickname){
-        List<User> userList = userReader.findByName(nickname);
-        int nicknameNumber = userList.size() + 1;
+    private Long countDuplicatedNickname(String nickname){
+        //List<User> userList = userReader.findByName(nickname);
+        //int nicknameNumber = userList.size() + 1;
+        Long nicknameNumber = userReader.countByName(nickname);
         return nicknameNumber;
     }
 

--- a/src/main/java/io/urdego/urdego_user_service/domain/service/components/UserReader.java
+++ b/src/main/java/io/urdego/urdego_user_service/domain/service/components/UserReader.java
@@ -19,8 +19,12 @@ import java.util.List;
 public class UserReader {
     private final UserRepository userRepository;
 
-    public List<User> findByName(String nickname){
+  /*  public List<User> findByName(String nickname){
         return userRepository.findByName(nickname);
+    }*/
+
+    public Long countByName(String nickname){
+        return userRepository.countByName(nickname);
     }
 
     public User readByUserId(Long userId) {

--- a/src/test/java/io/urdego/urdego_user_service/domain/service/components/UserCommanderTest.java
+++ b/src/test/java/io/urdego/urdego_user_service/domain/service/components/UserCommanderTest.java
@@ -47,11 +47,10 @@ class UserCommanderTest {
     void signUp_ShouldCreateUserWithCharacter(){
         //given
         UserSignUpRequest request = new UserSignUpRequest("nickname","email@email.com","KAKAO","1");
-        List<User> userList = List.of(mock(User.class), mock(User.class));
 
         //1. 중복된 닉네임이 몇개 있는지 체크
-        when(userReader.findByName(request.nickname())).thenReturn(userList);
-        int nicknameNumber = userList.size() + 1;
+        when(userReader.countByName(request.nickname())).thenReturn(1L);
+        Long nicknameNumber = 1L;
 
         //2. 유저 생성
         User dummyUser = User.create(request,nicknameNumber);
@@ -74,9 +73,9 @@ class UserCommanderTest {
 
         //5.1 중복된 닉네임이 몇개 있는지 체크
         //검증
-        verify(userReader).findByName(request.nickname());
+        verify(userReader).countByName(request.nickname());
         //확인
-        assertEquals("nickname#3",result.getNickname());
+        assertEquals("nickname#1",result.getNickname());
 
         //5.2 유저 생성
         //검증
@@ -110,11 +109,10 @@ class UserCommanderTest {
     void reSignUp_ShouldInitializeUserWithCharacter(){
         //given
         UserSignUpRequest request = new UserSignUpRequest("nickname","email@email.com","KAKAO","1");
-        List<User> userList = List.of(mock(User.class), mock(User.class));
 
         //1. 중복 닉네임 수 체크
-        when(userReader.findByName(request.nickname())).thenReturn(userList);
-        int nicknameNumber = userList.size() + 1;
+        when(userReader.countByName(request.nickname())).thenReturn(2L);
+        Long nicknameNumber = 2L;
 
         //탈퇴된 더미 유저 생성
         User dummyDeletedUser = User.create(request,nicknameNumber);
@@ -126,8 +124,8 @@ class UserCommanderTest {
 
         //then
         //1. 중복 닉네임 수 검증
-        verify(userReader).findByName(request.nickname());
-        assertEquals("nickname#3",result.getNickname());
+        verify(userReader).countByName(request.nickname());
+        assertEquals("nickname#2",result.getNickname());
 
         //2. 탈퇴된 더미 유저의 상태가 바뀌었는지( 정상 유저로 초기화 됐는지) 검증 및 확인
         assertEquals(false,result.getIsDeleted());


### PR DESCRIPTION
JpQuery를 이용하여 닉네임 중복 방지를 위한 닉네임 넘버링 성능 개선